### PR TITLE
parse output of recent Jabref

### DIFF
--- a/bibtexParse.js
+++ b/bibtexParse.js
@@ -293,7 +293,7 @@
                     this.string();
                 } else if (d == "@PREAMBLE") {
                     this.preamble();
-                } else if (d == "@COMMENT") {
+                } else if (d == "@COMMENT" || d == "@Comment") {
                     this.comment();
                 } else {
                     this.entry(d);


### PR DESCRIPTION
this patch enables parsing the direct output of JabRef 3.8.  However, looking at the unit tests, there are test cases for ```@comment``` to be treated as entry whereas only ```@COMMENT``` is treated special.
Since the current JabRef writes some non-parsable text into ```@Comment``` this patch would enable loading files produced by JabRef.   
It appears to me that BibTeX entry names and key names should be case insensitive, so maybe it is better to edit the unit-tests and change line 290 from
```var d = this.directive();``` to
```var d = this.directive().toUpperCase();```