### PR TITLE
Case insensitive for entries comment, preamble, and string

### DIFF
--- a/bibtexParse.js
+++ b/bibtexParse.js
@@ -24,7 +24,7 @@
 (function(exports) {
 
     function BibtexParser() {
-        
+
         this.months = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"];
         this.notKey = [',','{','}',' ','='];
         this.pos = 0;
@@ -176,7 +176,7 @@
                     return k.toLowerCase();
                 else
                     throw "Value expected:" + this.input.substring(start) + ' for key: ' + k;
-            
+
             };
         };
 
@@ -206,7 +206,7 @@
                     return this.input.substring(start, this.pos);
                 } else {
                     this.pos++;
-                    
+
                 };
             };
         };
@@ -243,7 +243,7 @@
             this.currentEntry = {};
             this.currentEntry['citationKey'] = this.key(true);
             this.currentEntry['entryType'] = d.substring(1);
-            if (this.currentEntry['citationKey'] != null) {            
+            if (this.currentEntry['citationKey'] != null) {
                 this.match(",");
             }
             this.key_value_list();
@@ -289,11 +289,11 @@
             while (this.matchAt()) {
                 var d = this.directive();
                 this.match("{");
-                if (d == "@STRING") {
+                if (d.toUpperCase() == "@STRING") {
                     this.string();
-                } else if (d == "@PREAMBLE") {
+                } else if (d.toUpperCase() == "@PREAMBLE") {
                     this.preamble();
-                } else if (d == "@COMMENT" || d == "@Comment") {
+                } else if (d.toUpperCase() == "@COMMENT") {
                     this.comment();
                 } else {
                     this.entry(d);
@@ -304,7 +304,7 @@
             this.alernativeCitationKey();
         };
     };
-    
+
     exports.toJSON = function(bibtex) {
         var b = new BibtexParser();
         b.setInput(bibtex);
@@ -334,7 +334,7 @@
             out += '}\n\n';
         }
         return out;
-        
+
     };
 
 })(typeof exports === 'undefined' ? this['bibtexParse'] = {} : exports);

--- a/test/PaglioneBibTeX.js
+++ b/test/PaglioneBibTeX.js
@@ -8,16 +8,6 @@ const input = `
 
   @COMMENT{"\nslkdjflksdjflkdsjf"}
 
-  @comment{paglione2001mapping,
-    title={A Mapping Survey of the 13CO and 12CO Emission in Galaxies},
-    author={Paglione, T.A.D. and Wall, WF and Young, J.S. and Heyer, M.H. and Richard, M. and Goldstein, M. and Kaufman, Z. and Nantais, J. and Perry, G.},
-    journal={The Astrophysical Journal Supplement Series},
-    volume={135},
-    pages={183},
-    year={2001},
-    publisher={IOP Publishing}
-  }
-
   @article{paglione2001mapping,
     title={A Mapping Survey of the 13CO and 12CO Emission in Galaxies},
     author={Paglione, T.A.D. and Wall, WF and Young, J.S. and Heyer, M.H. and Richard, M. and Goldstein, M. and Kaufman, Z. and Nantais, J. and Perry, G.},
@@ -505,19 +495,9 @@ const input = `
   }
 `;
 
-const output = 
+const output =
 [ { entryType: 'PREAMBLE', entry: '"ewcommand{oopsort}[1]{}"' },
   { entryType: 'COMMENT', entry: '"slkdjflksdjflkdsjf"' },
-  { citationKey: 'paglione2001mapping',
-    entryType: 'comment',
-    entryTags:
-     { title: 'A Mapping Survey of the 13CO and 12CO Emission in Galaxies',
-       author: 'Paglione, T.A.D. and Wall, WF and Young, J.S. and Heyer, M.H. and Richard, M. and Goldstein, M. and Kaufman, Z. and Nantais, J. and Perry, G.',
-       journal: 'The Astrophysical Journal Supplement Series',
-       volume: '135',
-       pages: '183',
-       year: '2001',
-       publisher: 'IOP Publishing' } },
   { citationKey: 'paglione2001mapping',
     entryType: 'article',
     entryTags:

--- a/test/comment.js
+++ b/test/comment.js
@@ -8,30 +8,9 @@ const input = `
 	@COMMENT{"\nslkdjflksdjflkdsjf"}
 
 	% test
-
-	@comment{paglione2001mapping,
-	  title={A Mapping Survey of the 13CO and 12CO Emission in Galaxies},
-	  author={Paglione, T.A.D. and Wall, WF and Young, J.S. and Heyer, M.H. and Richard, M. and Goldstein, M. and Kaufman, Z. and Nantais, J. and Perry, G.},
-	  journal={The Astrophysical Journal Supplement Series},
-	  volume={135},
-	  pages={183}, %test end comment out
-	  year={2001},
-	  %comment out ={}
-	  publisher={IOP % comment middel works  test Publishing}
-	}
 `;
 
 const output = [ { entryType: 'PREAMBLE', entry: '"ewcommand{oopsort}[1]{}"' },
-  { entryType: 'COMMENT', entry: '"slkdjflksdjflkdsjf"' },
-  { citationKey: 'paglione2001mapping',
-    entryType: 'comment',
-    entryTags:
-     { title: 'A Mapping Survey of the 13CO and 12CO Emission in Galaxies',
-       author: 'Paglione, T.A.D. and Wall, WF and Young, J.S. and Heyer, M.H. and Richard, M. and Goldstein, M. and Kaufman, Z. and Nantais, J. and Perry, G.',
-       journal: 'The Astrophysical Journal Supplement Series',
-       volume: '135',
-       pages: '183',
-       year: '2001',
-       publisher: 'IOP % comment middel works  test Publishing' } } ]
+  { entryType: 'COMMENT', entry: '"slkdjflksdjflkdsjf"' } ]
 
-test('Should parse commwnt', t => t.deepEqual(output, bibtexParse.toJSON(input)));
+test('Should parse comment', t => t.deepEqual(output, bibtexParse.toJSON(input)));


### PR DESCRIPTION
Adopt a case insensitive approach can avoid problems when parsing files containing entries named @comment, for example.