### PR TITLE
Ignore tabs and other whitespace in field keys

### DIFF
--- a/bibtexParse.js
+++ b/bibtexParse.js
@@ -216,6 +216,7 @@
             if (this.tryMatch("=")) {
                 this.match("=");
                 var val = this.value();
+                key = key.trim()
                 return [ key, val ];
             } else {
                 throw "... = value expected, equals sign missing:"

--- a/test/whitespace.js
+++ b/test/whitespace.js
@@ -1,0 +1,17 @@
+import test from 'ava';
+
+const bibtexParse = require('../bibtexParse');
+
+const input = `
+  @article{SomeKey,
+   author     = {John Doe},
+   title\t= {Foo Bar},
+  journal=\t{Transactions on Foobar},
+         \tvolume\t  =   {42},
+\tyear \t={2017}
+  }
+`;
+
+const output = [{citationKey:"SomeKey",entryType:"article",entryTags: {author:"John Doe",title:"Foo Bar",journal:"Transactions on Foobar",volume:"42",year:"2017"}}]
+
+test('Ignore tabs and other whitespace in field keys', t => t.deepEqual(output, bibtexParse.toJSON(input)));


### PR DESCRIPTION
Tabs between bibtex entry field keys and the equal sign were not parsing correctly. For example, ``author=(TAB){John Doe}``

One commit is the one-liner fix, the other is a unit test.

I ran into this issue with a bib file produced by the [bibtool](https://www.ctan.org/pkg/bibtool?lang=en) application.