### PR TITLE
IE11 doesn't allow default function parameters

### DIFF
--- a/bibtexParse.js
+++ b/bibtexParse.js
@@ -320,7 +320,8 @@
     /* Increased the amount of white-space to make entries
      * more attractive to humans. Pass compact as false
      * to enable */
-    exports.toBibtex = function(json, compact=true) {
+    exports.toBibtex = function(json, compact) {
+        if (compact === undefined) compact = true;
         var out = '';
         
         var entrysep = ',';


### PR DESCRIPTION
It turns out IE11 (still default for 15% of our visitors, unfortunately) doesn't accept default function parameters. Simple but annoying to fix. Sorry for the inconvenience.