### PR TITLE
Move test framework to deveDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,8 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {
-    "ava": "^0.23.0",
-    "xml2js": "*"
+  "devDependencies": {
+    "ava": "^0.23.0"
   },
   "scripts": {
     "test": "ava"


### PR DESCRIPTION
Installing the single-file `bibtex-parse-js` currently loads over 100 other packages, due to `ava`.

By moving `ava` to the `devDependencies`, it should only be loaded when development/testing is desired.

`xml2js` seems to be unused at all?

Pushing this as PR to see if Travis CI properly installs the package with `devDependencies` enabled.