### PR TITLE
Fix parsing of a key-like value at end of entry

### DIFF
--- a/bibtexParse.js
+++ b/bibtexParse.js
@@ -172,7 +172,7 @@
             } else if (this.tryMatch('"')) {
                 return this.value_quotes();
             } else {
-                var k = this.key();
+                var k = this.key().trim();
                 if (k.match("^[0-9]+$"))
                     return k;
                 else if (this.months.indexOf(k.toLowerCase()) >= 0)

--- a/test/proceedings.js
+++ b/test/proceedings.js
@@ -1,0 +1,28 @@
+import test from 'ava';
+
+const bibtexParse = require('../bibtexParse');
+
+const input = `@proceedings{Last:2020:P20I3,
+  doi = {10.22152/programming-journal.org/2020/4/issue3},
+  editor = {Last, First},
+  month = {February},
+  publisher = {AOSA Inc.},
+  title = {The Art, Science, and Engineering of Programming},
+  url = {https://programming-journal.org/2020/4/issue3/},
+  volume = 4,
+  year = 2020
+}`
+
+const output = [ { citationKey: 'Last:2020:P20I3',
+    entryType: 'proceedings',
+    entryTags:
+     { title: 'The Art, Science, and Engineering of Programming',
+       year: '2020',
+       month: 'February',
+       editor: 'Last, First',
+       publisher: 'AOSA Inc.',
+       volume: '4',
+       doi: '10.22152/programming-journal.org/2020/4/issue3',
+       url: 'https://programming-journal.org/2020/4/issue3/' } } ]
+
+test('proceedings should parse', t => t.deepEqual(output, bibtexParse.toJSON(input)));


### PR DESCRIPTION
This adds a test and fix for a year value failing a regex check.

Perhaps the trim should be done inside the key() function, would avoid other potential issues.